### PR TITLE
support bulk value setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Define a unique key for a context value, without type conversion:
 ```go
 ctxMyKey := ctxkey.New[string]()
 
-ctx := ctxMyKey.WithValue(context.Background(), "value")
+ctx := ctxMyKey.Set(context.Background(), "value")
 
 fmt.Println(ctxMyKey.Value(ctx)) // "value", true 
 ```
@@ -30,7 +30,7 @@ Check if a key has a value, or panic if not found:
 
 ```go
 ctxMyKey := ctxkey.New[string]()
-ctx := ctxMyKey.WithValue(context.Background(), "value")
+ctx := ctxMyKey.Set(context.Background(), "value")
 
 value, ok := ctxMyKey.Value(ctx)
 if !ok {
@@ -48,7 +48,7 @@ ctxMyKey := ctxkey.NewWithDefault("defaultValue")
 ctx := context.Background()
 value := ctxMyKey.Value(ctx) // "defaultValue"
 
-ctx = ctxMyKey.WithValue(ctx, "newValue")
+ctx = ctxMyKey.Set(ctx, "newValue")
 value = ctxMyKey.MustNonEmptyValue(ctx) // "newValue"
 ```
 
@@ -58,15 +58,43 @@ Provide a box for a key to store a value, useful in cases where it is not conven
 var ctxMyKey = ctxkey.NewBoxedWithDefault[string](nil)
 
 func inner(ctx context.Context) {   
-    ctxMyKey.WithValue(ctx, "value")
+    ctxMyKey.Set(ctx, "value") 
+    // note that the context is not returned
 }
 
 func outer() {
     ctx := context.Background()
-    ctxMyKey.WithBox(ctx)
-
+    ctxMyKey.SetBox(ctx)
+	
     inner(ctx)
 
     value := ctxMyKey.MustValue(ctx) // "value"
 }
+```
+
+### Composition
+
+The `With` helpers can be used to compose multiple keys into a single context.
+
+```go
+ctxMyKey := ctxkey.New[string]()
+ctxMyKey2 := ctxkey.New[int]()
+ctxMyKey3 := ctxkey.New[string]()
+ctxMyKey4 := ctxkey.NewWithDefault("default")
+
+firstValueSet := ctxMyKey.WithValue("first")
+twoAndThreeSet := ctxkey.With(
+    ctxMyKey2.WithValue(42),
+    ctxMyKey3.WithValue("third"),
+)
+
+ctx := ctxkey.With(
+    firstValueSet,
+    twoAndThreeSet,
+)(context.Background())
+
+value, ok := ctxMyKey.Value(ctx) // "first", true
+value, ok = ctxMyKey2.Value(ctx) // 42, true
+value, ok = ctxMyKey3.Value(ctx) // "third", true
+value, ok = ctxMyKey4.Value(ctx) // "default", true
 ```

--- a/examples/http/main.go
+++ b/examples/http/main.go
@@ -38,7 +38,7 @@ func authorizeUserMiddleware(next http.Handler) http.Handler {
 		ctxLogger.MustNonEmptyValue(r.Context()).Info("authorizing user", "name", name)
 
 		user := &User{ID: 1, Name: name}
-		r = r.WithContext(ctxAuthorizedUser.WithValue(r.Context(), *user))
+		r = r.WithContext(ctxAuthorizedUser.Set(r.Context(), *user))
 		next.ServeHTTP(w, r)
 	})
 }
@@ -47,7 +47,7 @@ func authorizeUserMiddleware(next http.Handler) http.Handler {
 func bytesWrittenLoggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// carve out a spot in the context for the value to be written
-		r = r.WithContext(ctxBytesWritten.WithBox(r.Context()))
+		r = r.WithContext(ctxBytesWritten.SetBox(r.Context()))
 
 		// run the wrapped handler
 		next.ServeHTTP(w, r)
@@ -68,7 +68,7 @@ var helloHandler http.HandlerFunc = func(w http.ResponseWriter, req *http.Reques
 	}
 
 	// fill in the "box" that is already present in the ctx
-	ctxBytesWritten.WithValue(req.Context(), written)
+	ctxBytesWritten.Set(req.Context(), written)
 }
 
 func main() {


### PR DESCRIPTION
This is a breaking API change (but we haven't tagged a release yet!)

This changes the key types to have a signature like:

```go
Set(ctx context.Context, val V) context.Context
With(val V) func(ctx context.Context) context.Context
```

```go
// old api
ctx = context.Background()
ctx = myCtxKey.WithValue(ctx, "old")

// new api
ctx = context.Background()
ctx = myCtxKey.Set(ctx, "new")
// or
ctx = myCtxKey.With("new")(ctx)
```

It's a minor change to these apis, but it makes it easy to bulk apply values with the new `With` helpers:

here's an example:
```go
// old: add each value one at a time
ctx = context.Background()
ctx = CtxKubeClient.WithValue(ctx, clientset)
ctx = CtxDynamicClient.WithValue(ctx, dynamicClient)
ctx = CtxMetaClient.WithValue(ctx, metaClient)
ctx = CtxNamespace.WithValue(ctx, namespace)

// new: bulk apply ctx values
ctx := ctxkey.With(
  CtxKubeClient.With(clientset),
  CtxDynamicClient.With(dynamicClient),
  CtxMetaClient.With(metaClient),
  CtxNamespace.With(namespace),
)(context.Background())

// note that `With` is the same signature and can therefore be nested:
clientValues := ctxkey.With(
  CtxKubeClient.With(clientset),
  CtxDynamicClient.With(dynamicClient),
  CtxMetaClient.With(metaClient),
)

ctx := ctxkey.With(
  clientValues
  CtxNamespace.With(namespace),
)(context.Background())
```